### PR TITLE
🐛 fix multiple error window bug

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
 

--- a/pkg/mousemover/mouseMover.go
+++ b/pkg/mousemover/mouseMover.go
@@ -68,10 +68,11 @@ func (m *MouseMover) run(heartbeatCh chan *tracker.Heartbeat, activityTracker *t
 						} else {
 							didNotMoveCount := state.getDidNotMoveCount()
 							state.updateDidNotMoveCount(didNotMoveCount + 1)
-							msg := fmt.Sprintf("Mouse pointer cannot be moved at %v. Last moved at %v. Happened %v times. See README for details.",
+							state.updateLastErrorTime(time.Now())
+							msg := fmt.Sprintf("Mouse pointer cannot be moved at %v. Last moved at %v. Happened %v times. (Only notifies once every 24 hours.) See README for details.",
 								time.Now(), state.getLastMouseMovedTime(), state.getDidNotMoveCount())
 							logger.Errorf(msg)
-							if state.getDidNotMoveCount() >= 10 {
+							if state.getDidNotMoveCount() >= 10 && (time.Since(state.lastErrorTime).Hours() > 24) { //show only 1 error in a 24 hour window
 								go func() {
 									robotgo.ShowAlert("Error with Automatic Mouse Mover", msg)
 								}()

--- a/pkg/mousemover/mouseMoverUtil.go
+++ b/pkg/mousemover/mouseMoverUtil.go
@@ -94,6 +94,18 @@ func (s *state) updateLastMouseMovedTime(time time.Time) {
 	s.lastMouseMovedTime = time
 }
 
+func (s *state) getLastErrorTime() time.Time {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.lastErrorTime
+}
+
+func (s *state) updateLastErrorTime(time time.Time) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.lastErrorTime = time
+}
+
 func (s *state) getDidNotMoveCount() int {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()

--- a/pkg/mousemover/mouseMover_test.go
+++ b/pkg/mousemover/mouseMover_test.go
@@ -166,6 +166,7 @@ func (suite *TestMover) TestMouseMoveFailure() {
 	assert.False(t, state.isSystemSleeping(), "machine should not be sleeping")
 	assert.True(t, time.Time.IsZero(state.getLastMouseMovedTime()), "should be default")
 	assert.Equal(t, state.getDidNotMoveCount(), 0, "should be 0")
+	assert.True(t, state.getLastErrorTime().IsZero(), "should be default")
 
 	heartbeatCh <- &tracker.Heartbeat{
 		WasAnyActivity: false,
@@ -174,4 +175,5 @@ func (suite *TestMover) TestMouseMoveFailure() {
 	time.Sleep(time.Millisecond * 500) //wait for it to be registered
 	assert.True(t, time.Time.IsZero(state.getLastMouseMovedTime()), "should be default but is ", state.getLastMouseMovedTime())
 	assert.NotEqual(t, state.getDidNotMoveCount(), 0, "should not be 0")
+	assert.NotEqual(t, state.getLastErrorTime(), 0, "should not be 0")
 }

--- a/pkg/mousemover/types.go
+++ b/pkg/mousemover/types.go
@@ -19,6 +19,7 @@ type state struct {
 	isAppRunning       bool
 	isSysSleeping      bool
 	lastMouseMovedTime time.Time
+	lastErrorTime      time.Time
 	didNotMoveCount    int
 	override           *override
 }


### PR DESCRIPTION
This PR ensures that only 1 error window appears in 24 hours. Suppressing through logs was not an option since I would like the user to know that AMM is unable to move their mouse.

fix https://github.com/prashantgupta24/automatic-mouse-mover/issues/35